### PR TITLE
Mp surveyjs apialt.md

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "cSpell.words": [
+        "Maharshi"
+    ]
+}

--- a/survey-js-form-card.js
+++ b/survey-js-form-card.js
@@ -13,32 +13,33 @@ class SurveyCard extends LitElement {
   }
 
   setConfig(config) {
-    console.log("Config", this, config);
-    this.config = config;
-    this.survey = null;
-    this.survey_timer = null;
-    this.survey_state = "";
-    this.customCss = "";
-    this.noUiSliderStyles = "";
-    this.globalCss = "";
-    this.getCustomCss();
 
-    setTimeout(() => {
+      this.config = config;
+      // console.log("Config", this.config);
+      this.survey = null;
+      this.survey_timer = null;
+      this.survey_state = "";
+      this.customCss = "";
+      this.noUiSliderStyles = "";
+      this.globalCss = "";
+      this.getCustomCss();
+
+      setTimeout(() => {
       if (
-        this._hass?.states[this.config?.state_life_cycle_entity]?.state ===
+          this._hass?.states[this.config?.state_life_cycle_entity]?.state ===
           "sent" ||
-        this._hass?.states[this.config?.state_life_cycle_entity]?.state ===
+          this._hass?.states[this.config?.state_life_cycle_entity]?.state ===
           "started"
       ) {
-        this.startTimer(
+          this.startTimer(
           this._hass.states[this.config?.state_life_cycle_entity].state
-        );
+          );
       } else {
-        clearInterval(this.survey_timer);
+          clearInterval(this.survey_timer);
       //  console.log("Interval Cleared");        // : Comment in production
       }
       // console.log(this.survey_timer);           // : Comment in production
-    }, 500);
+      }, 500);
   }
 
   set hass(hass) {
@@ -127,7 +128,9 @@ class SurveyCard extends LitElement {
       // );                                                                              // : Replaced with callService
 
       this._hass.callService("input_select", "select_option", {'entity_id': this.config?.state_life_cycle_entity, 'option': 'started'});
-      this._hass.callService("timer", "start", {'entity_id': this.config?.expiry_timer.name, 'duration': this.config.expiry_timer.duration});
+      // console.log(this._hass?.states[this.config?.state_life_cycle_entity] )
+      this._hass.callService("timer", "start", { 'entity_id': this.config?.expiry_timer[0].name, 'duration': this.config.expiry_timer[0].duration });
+      // console.log(this._hass?.states[this.config?.expiry_timer.name] )
 
       // setTimeout(() => {
       //   this._hass.callApi("POST", "states/" + this.config.entity, {
@@ -138,14 +141,14 @@ class SurveyCard extends LitElement {
       //   });
 
       // }, 500);                                                                        // TODO: Replace with Hass timer and init w/callService
-    } 
+    }
     // if state is started, gets remaining time from entity and sets timer
     else if (state == "started") {
       // CONSIDER: Add a check for timer state and remaining time
       // check the timer state;
       // if timer is idle, set state to received and clear timer
       // if timer is active, get remaining time and set timer
-      
+
       // OLD CODE
       // this._hass.callApi("GET", "states/" + this.config.entity).then((data) => {
       //   // console.log("Get Entity Data", data);                                      // : Comment in production
@@ -178,11 +181,11 @@ class SurveyCard extends LitElement {
       //   thisHassNode.survey.doComplete();
       // }
 
-      if (this._hass.states[this.config?.expiry_timer.name]?.state == 'idle') {
+      if (this._hass?.states[this.config?.expiry_timer[0].name] == 'idle') {
         clearInterval(thisHassNode.survey_timer);
         thisHassNode.survey_state = "received";
         thisHassNode.survey.doComplete();
-      }     
+      }
     }, 1000);
   }
 
@@ -205,7 +208,7 @@ class SurveyCard extends LitElement {
       thisNode.pageCssLogic(options);
     });
 
-    this.survey_state = "received";
+  //   this.survey_state = "received";
 
     this.survey.onComplete.add((sender) => {
       // this._hass.callApi(
@@ -214,13 +217,7 @@ class SurveyCard extends LitElement {
       //   {
       //     state: this.survey_state,
       //   }
-      // )
-      this._hass.callService("input_select", "select_option", 
-        {
-          'entity_id': this.config?.state_life_cycle_entity,
-          'option': this.survey_state
-        }
-      );                                                                          // : Replace with callService
+      // )                                                                         // : Replace with callService
 
       // console.log("Survey Completed", sender.data);                            // : Comment in production
 
@@ -248,14 +245,15 @@ class SurveyCard extends LitElement {
         //       survey_response: results,
         //     }),
         //   }) // Replace with callService
-        this._hass.callService("input_text", "set_value", 
+        this._hass.callService("input_text", "set_value",
           {
-            "entity_id": this.config?.survey_response_entity, 
-            "value": JSON.stringify(results)}) 
+            "entity_id": this.config?.survey_response_entity,
+            "value": JSON.stringify(results)})
           .then((data) => {
             // console.log("Post Entity Data", data);                          // : Comment in production
-            // clearInterval(this.survey_timer);
-            this._hass.callService("timer", "cancel", {'entity_id': this.config?.expiry_timer.name});
+              // clearInterval(this.survey_timer);
+              // console.log(this.config?.expiry_timer[0].name)
+            this._hass.callService("timer", "cancel", {'entity_id': this.config?.expiry_timer[0].name});
             let thank_you_element =
               this.shadowRoot.querySelector(".sd-completedpage");
             thank_you_element.innerText =
@@ -264,7 +262,7 @@ class SurveyCard extends LitElement {
             thank_you_element.onclick = function () {
               window.location.href = "/";
             };
-          });                                                             // : adds a thank you page, 
+          });                                                             // : adds a thank you page,
       }, 500);
     });
 

--- a/survey-js-form-card.js
+++ b/survey-js-form-card.js
@@ -35,37 +35,37 @@ class SurveyCard extends LitElement {
         );
       } else {
         clearInterval(this.survey_timer);
-        console.log("Interval Cleared");
+      //  console.log("Interval Cleared");        // TODO: Comment in production
       }
-      console.log(this.survey_timer);
+      // console.log(this.survey_timer);           // TODO: Comment in production
     }, 500);
   }
 
   set hass(hass) {
-    console.log("Hass", hass);
+    // console.log("Hass", hass);                  // TODO: Comment in production
     this._hass = hass;
   }
 
   firstUpdated() {
-    console.log("Hi", this.config);
+    // console.log("Hi", this.config);             // TODO: Comment in production
     var thisNode = this;
     $(document).ready(function () {
-      console.log("Jquery working");
+      // console.log("Jquery working");            // TODO: Comment in production
       $.getScript("https://unpkg.com/survey-jquery/survey.jquery.min.js").done(
         (script, textStatus) => {
-          console.log(thisNode);
+          // console.log(thisNode);                // TODO: Comment in production
           thisNode.constructSurveyUI();
         }
       );
       $.getScript(
         "https://unpkg.com/surveyjs-widgets@1.9.90/surveyjs-widgets.min.js"
       ).done((script, textStatus) => {
-        console.log("Survey JS Widgets loaded");
+        // console.log("Survey JS Widgets loaded");  // TODO: Comment in production
       });
       $.getScript(
         "https://cdnjs.cloudflare.com/ajax/libs/showdown/1.6.4/showdown.min.js"
       ).done((script, textStatus) => {
-        console.log("Showdown loaded");
+        // console.log("Showdown loaded");         // TODO: Comment in production
       });
     });
   }
@@ -85,11 +85,11 @@ class SurveyCard extends LitElement {
         this.config?.globalCss + "?" + Math.random()
       );
 
-      console.log(
-        this.customCss?.default,
-        this.noUiSliderStyles?.default,
-        this.globalCss?.default
-      );
+      // console.log(
+      //   this.customCss?.default,
+      //   this.noUiSliderStyles?.default,
+      //   this.globalCss?.default
+      // );                                        // TODO: Comment in production
 
       let prependStyle = this.shadowRoot.createElement("style");
 
@@ -135,7 +135,7 @@ class SurveyCard extends LitElement {
       }, 500);
     } else if (state == "started") {
       this._hass.callApi("GET", "states/" + this.config.entity).then((data) => {
-        console.log("Get Entity Data", data);
+        // console.log("Get Entity Data", data);                                      // TODO: Comment in production
         countDownDate = new Date(data.attributes.start_timer_date);
       });
     }
@@ -157,7 +157,7 @@ class SurveyCard extends LitElement {
       console.log(
         days + "d " + hours + "h " + minutes + "m " + seconds + "s ",
         thisHassNode.survey_timer
-      );
+      );                                                                      // TODO: Comment in production
 
       if (distance < 0) {
         clearInterval(thisHassNode.survey_timer);
@@ -170,17 +170,17 @@ class SurveyCard extends LitElement {
   constructSurveyUI() {
     var thisNode = this;
     window["surveyjs-widgets"].nouislider(Survey);
-    console.log("Script accesed", Survey, "Config", this.config, noUiSlider);
+    // console.log("Script accesed", Survey, "Config", this.config, noUiSlider); // TODO: Comment in production
 
     this.survey = new Survey.Model(this.config.surveyjs_json);
-    console.log(
-      "Survey Model",
-      this.survey,
-      this.survey.visiblePages,
-      this.survey.currentPageNo
-    );
+    // console.log(
+    //   "Survey Model",
+    //   this.survey,
+    //   this.survey.visiblePages,
+    //   this.survey.currentPageNo
+    // );                                                                         // TODO: Comment in production
 
-    console.log(this.config.surveyjs_json);
+    // console.log(this.config.surveyjs_json);                                   // TODO: Comment in production
 
     this.survey.onUpdateQuestionCssClasses.add(function (_, options) {
       thisNode.pageCssLogic(options);
@@ -215,7 +215,7 @@ class SurveyCard extends LitElement {
             attributes: results,
           })
           .then((data) => {
-            console.log("Post Entity Data", data);
+            // console.log("Post Entity Data", data);                          // TODO: Comment in production
             clearInterval(this.survey_timer);
             let thank_you_element =
               this.shadowRoot.querySelector(".sd-completedpage");
@@ -251,11 +251,11 @@ class SurveyCard extends LitElement {
   }
 
   pageCssLogic(options) {
-    console.log(options, "Custom CSS", options.question.getType());
+    // console.log(options, "Custom CSS", options.question.getType());                 // TODO: Comment in production
 
     let elementsData;
     if (this.config.surveyjs_json?.elements) {
-      console.log("Only one element");
+      // console.log("Only one element");                                              // TODO: Comment in production
       elementsData = this.config.surveyjs_json?.elements;
     } else {
       elementsData =
@@ -281,19 +281,19 @@ class SurveyCard extends LitElement {
 
         // classes[classKey] = classValue;
 
-        console.log(
-          "Available",
-          ele.type,
-          this.survey.css,
-          ele?.customCssClassDetails
-        );
+        // console.log(
+        //   "Available",
+        //   ele.type,
+        //   this.survey.css,
+        //   ele?.customCssClassDetails
+        // );                                                                       // TODO: Comment in production
         break;
       }
     }
   }
 
   cssClassUpdation(classes, classKey, classValue, questionType) {
-    console.log(classes, classKey, classValue, questionType, "Classes");
+    console.log(classes, classKey, classValue, questionType, "Classes");               // TODO: Comment in production
     classKey.forEach((v, i) => {
       classes[v] = classValue[i];
     });
@@ -303,7 +303,7 @@ class SurveyCard extends LitElement {
       this.survey.onTextMarkdown.add(function (survey, options) {
         //convert the markdown text to html
 
-        console.log(options, options.html);
+        // console.log(options, options.html);                                            // TODO: Comment in production
 
         var str = converter.makeHtml(options.text);
         //remove root paragraphs <p></p>

--- a/survey-js-form-card.js
+++ b/survey-js-form-card.js
@@ -35,37 +35,37 @@ class SurveyCard extends LitElement {
         );
       } else {
         clearInterval(this.survey_timer);
-      //  console.log("Interval Cleared");        // TODO: Comment in production
+      //  console.log("Interval Cleared");        // : Comment in production
       }
-      // console.log(this.survey_timer);           // TODO: Comment in production
+      // console.log(this.survey_timer);           // : Comment in production
     }, 500);
   }
 
   set hass(hass) {
-    // console.log("Hass", hass);                  // TODO: Comment in production
+    // console.log("Hass", hass);                  // : Comment in production
     this._hass = hass;
   }
 
   firstUpdated() {
-    // console.log("Hi", this.config);             // TODO: Comment in production
+    // console.log("Hi", this.config);             // : Comment in production
     var thisNode = this;
     $(document).ready(function () {
-      // console.log("Jquery working");            // TODO: Comment in production
+      // console.log("Jquery working");            // : Comment in production
       $.getScript("https://unpkg.com/survey-jquery/survey.jquery.min.js").done(
         (script, textStatus) => {
-          // console.log(thisNode);                // TODO: Comment in production
+          // console.log(thisNode);                // : Comment in production
           thisNode.constructSurveyUI();
         }
       );
       $.getScript(
         "https://unpkg.com/surveyjs-widgets@1.9.90/surveyjs-widgets.min.js"
       ).done((script, textStatus) => {
-        // console.log("Survey JS Widgets loaded");  // TODO: Comment in production
+        // console.log("Survey JS Widgets loaded");  // : Comment in production
       });
       $.getScript(
         "https://cdnjs.cloudflare.com/ajax/libs/showdown/1.6.4/showdown.min.js"
       ).done((script, textStatus) => {
-        // console.log("Showdown loaded");         // TODO: Comment in production
+        // console.log("Showdown loaded");         // : Comment in production
       });
     });
   }
@@ -89,7 +89,7 @@ class SurveyCard extends LitElement {
       //   this.customCss?.default,
       //   this.noUiSliderStyles?.default,
       //   this.globalCss?.default
-      // );                                        // TODO: Comment in production
+      // );                                        // : Comment in production
 
       let prependStyle = this.shadowRoot.createElement("style");
 
@@ -125,19 +125,7 @@ class SurveyCard extends LitElement {
         }
       );                                                                              // TODO: Replace with callService
 
-      setTimeout(() => {
-        this._hass.callApi("POST", "states/" + this.config.entity, {
-          state: "started",
-          attributes: {
-            start_timer_date: countDownDate.getTime(),
-          },
-        });
-      }, 500);                                                                        // TODO: Replace with Hass timer and init w/callService
-    } else if (state == "started") {
-      this._hass.callApi("GET", "states/" + this.config.entity).then((data) => {
-        // console.log("Get Entity Data", data);                                      // TODO: Comment in production
-        countDownDate = new Date(data.attributes.start_timer_date);                   // TODO: check with Hass.state(timer) active and remaining time
-      });
+      //   // console.log("Get Entity Data", data);                                      // : Comment in production
     }
 
     var thisHassNode = this;
@@ -170,7 +158,7 @@ class SurveyCard extends LitElement {
   constructSurveyUI() {
     var thisNode = this;
     window["surveyjs-widgets"].nouislider(Survey);
-    // console.log("Script accesed", Survey, "Config", this.config, noUiSlider); // TODO: Comment in production
+    // console.log("Script accesed", Survey, "Config", this.config, noUiSlider); // : Comment in production
 
     this.survey = new Survey.Model(this.config.surveyjs_json);
     // console.log(
@@ -180,7 +168,7 @@ class SurveyCard extends LitElement {
     //   this.survey.currentPageNo
     // );                                                                         // TODO Comment in production
 
-    // console.log(this.config.surveyjs_json);                                   // TODO  Comment in production
+    // console.log(this.config.surveyjs_json);                                   //   Comment in production
 
     this.survey.onUpdateQuestionCssClasses.add(function (_, options) {
       thisNode.pageCssLogic(options);
@@ -195,7 +183,7 @@ class SurveyCard extends LitElement {
         {
           state: this.survey_state,
         }
-      );                                                                          // TODO: Replace with callService
+      // console.log("Survey Completed", sender.data);                            // : Comment in production
 
       setTimeout(() => {
         if (this.config?.floor_plan_location) {
@@ -253,11 +241,11 @@ class SurveyCard extends LitElement {
   }
 
   pageCssLogic(options) {
-    // console.log(options, "Custom CSS", options.question.getType());                 // TODO: Comment in production
+    // console.log(options, "Custom CSS", options.question.getType());                 // : Comment in production
 
     let elementsData;
     if (this.config.surveyjs_json?.elements) {
-      // console.log("Only one element");                                              // TODO: Comment in production
+      // console.log("Only one element");                                              // : Comment in production
       elementsData = this.config.surveyjs_json?.elements;
     } else {
       elementsData =
@@ -288,14 +276,14 @@ class SurveyCard extends LitElement {
         //   ele.type,
         //   this.survey.css,
         //   ele?.customCssClassDetails
-        // );                                                                       // TODO: Comment in production
+        // );                                                                       // : Comment in production
         break;
       }
     }
   }
 
   cssClassUpdation(classes, classKey, classValue, questionType) {
-    console.log(classes, classKey, classValue, questionType, "Classes");               // TODO: Comment in production
+    // console.log(classes, classKey, classValue, questionType, "Classes");               // : Comment in production
     classKey.forEach((v, i) => {
       classes[v] = classValue[i];
     });
@@ -305,7 +293,7 @@ class SurveyCard extends LitElement {
       this.survey.onTextMarkdown.add(function (survey, options) {
         //convert the markdown text to html
 
-        // console.log(options, options.html);                                            // TODO: Comment in production
+        // console.log(options, options.html);                                            // : Comment in production
 
         var str = converter.makeHtml(options.text);
         //remove root paragraphs <p></p>

--- a/survey-js-form-card.js
+++ b/survey-js-form-card.js
@@ -109,10 +109,10 @@ class SurveyCard extends LitElement {
   startTimer(state) {
     var countDownDate;
     if (state == "sent") {
-      countDownDate = new Date();
-      countDownDate.setMinutes(
-        countDownDate.getMinutes() + this.config.expiry_time_min
-      );
+      // countDownDate = new Date();
+      // countDownDate.setMinutes(
+      //   countDownDate.getMinutes() + this.config.expiry_time_min
+      // );
       // this._hass.callService("input_select.select_option", "started", {
       //   entity_id: this.config?.state_life_cycle_entity,
       // });
@@ -126,28 +126,34 @@ class SurveyCard extends LitElement {
       );                                                                              // TODO: Replace with callService
 
       //   // console.log("Get Entity Data", data);                                      // : Comment in production
+      //   countDownDate = new Date(data.attributes.start_timer_date);                   // TODO: check with Hass.state(timer) active and remaining time
+      // });
     }
 
     var thisHassNode = this;
 
     this.survey_timer = setInterval(function () {
-      var now = new Date().getTime();
+      // var now = new Date().getTime();
 
-      var distance = countDownDate - now;
+      // var distance = countDownDate - now;
 
-      var days = Math.floor(distance / (1000 * 60 * 60 * 24));
-      var hours = Math.floor(
-        (distance % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60)
-      );
-      var minutes = Math.floor((distance % (1000 * 60 * 60)) / (1000 * 60));
-      var seconds = Math.floor((distance % (1000 * 60)) / 1000);
+      // var days = Math.floor(distance / (1000 * 60 * 60 * 24));
+      // var hours = Math.floor(
+      //   (distance % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60)
+      // );
+      // var minutes = Math.floor((distance % (1000 * 60 * 60)) / (1000 * 60));
+      // var seconds = Math.floor((distance % (1000 * 60)) / 1000);
 
-      console.log(
-        days + "d " + hours + "h " + minutes + "m " + seconds + "s ",
-        thisHassNode.survey_timer
-      );                                                                      // TODO: Comment in production
-
-      if (distance < 0) {
+      // console.log(
+      //   // days + "d " + hours + "h " + minutes + "m " + seconds + "s ",
+      //   thisHassNode.survey_timer
+      // );                                                                      // : Comment in production
+      // when timer expires, sets state to received and clears timer
+      // if (distance < 0) {
+      //   clearInterval(thisHassNode.survey_timer);
+      //   thisHassNode.survey_state = "received";
+      //   thisHassNode.survey.doComplete();
+      // }
         clearInterval(thisHassNode.survey_timer);
         thisHassNode.survey_state = "received";
         thisHassNode.survey.doComplete();
@@ -166,7 +172,7 @@ class SurveyCard extends LitElement {
     //   this.survey,
     //   this.survey.visiblePages,
     //   this.survey.currentPageNo
-    // );                                                                         // TODO Comment in production
+    // );                                                                         //  Comment in production
 
     // console.log(this.config.surveyjs_json);                                   //   Comment in production
 
@@ -205,8 +211,9 @@ class SurveyCard extends LitElement {
             }),
           })
           .then((data) => {
-            // console.log("Post Entity Data", data);                          // TODO: Comment in production
-            clearInterval(this.survey_timer);
+            // console.log("Post Entity Data", data);                          // : Comment in production
+            // clearInterval(this.survey_timer);
+            this._hass.callService("timer", "cancel", {'entity_id': this.config?.expiry_timer.name});
             let thank_you_element =
               this.shadowRoot.querySelector(".sd-completedpage");
             thank_you_element.innerText =

--- a/survey-js-form-card.js
+++ b/survey-js-form-card.js
@@ -123,7 +123,7 @@ class SurveyCard extends LitElement {
         {
           state: "started",
         }
-      );
+      );                                                                              // TODO: Replace with callService
 
       setTimeout(() => {
         this._hass.callApi("POST", "states/" + this.config.entity, {
@@ -132,11 +132,11 @@ class SurveyCard extends LitElement {
             start_timer_date: countDownDate.getTime(),
           },
         });
-      }, 500);
+      }, 500);                                                                        // TODO: Replace with Hass timer and init w/callService
     } else if (state == "started") {
       this._hass.callApi("GET", "states/" + this.config.entity).then((data) => {
         // console.log("Get Entity Data", data);                                      // TODO: Comment in production
-        countDownDate = new Date(data.attributes.start_timer_date);
+        countDownDate = new Date(data.attributes.start_timer_date);                   // TODO: check with Hass.state(timer) active and remaining time
       });
     }
 
@@ -178,9 +178,9 @@ class SurveyCard extends LitElement {
     //   this.survey,
     //   this.survey.visiblePages,
     //   this.survey.currentPageNo
-    // );                                                                         // TODO: Comment in production
+    // );                                                                         // TODO Comment in production
 
-    // console.log(this.config.surveyjs_json);                                   // TODO: Comment in production
+    // console.log(this.config.surveyjs_json);                                   // TODO  Comment in production
 
     this.survey.onUpdateQuestionCssClasses.add(function (_, options) {
       thisNode.pageCssLogic(options);
@@ -195,7 +195,7 @@ class SurveyCard extends LitElement {
         {
           state: this.survey_state,
         }
-      );
+      );                                                                          // TODO: Replace with callService
 
       setTimeout(() => {
         if (this.config?.floor_plan_location) {
@@ -210,9 +210,11 @@ class SurveyCard extends LitElement {
         };
 
         this._hass
-          .callApi("POST", "states/" + this.config.entity, {
-            state: this.survey_state,
-            attributes: results,
+          .callService("notify", "update_sjs_reponse", {
+            message: JSON.stringify({
+              survey_lifecycle: "started",
+              survey_response: results,
+            }),
           })
           .then((data) => {
             // console.log("Post Entity Data", data);                          // TODO: Comment in production
@@ -225,7 +227,7 @@ class SurveyCard extends LitElement {
             thank_you_element.onclick = function () {
               window.location.href = "/";
             };
-          });
+          });                                                             // TDOD: adds a thank you page, 
       }, 500);
     });
 

--- a/survey-js-form-card.js
+++ b/survey-js-form-card.js
@@ -178,10 +178,11 @@ class SurveyCard extends LitElement {
       //   thisHassNode.survey.doComplete();
       // }
 
+      if (this._hass.states[this.config?.expiry_timer.name]?.state == 'idle') {
         clearInterval(thisHassNode.survey_timer);
         thisHassNode.survey_state = "received";
         thisHassNode.survey.doComplete();
-      }
+      }     
     }, 1000);
   }
 

--- a/surveyjs_api_alt.md
+++ b/surveyjs_api_alt.md
@@ -23,13 +23,9 @@ Interesting Solutions/ideas on community:
 - reasons for not using file sensor - file sensor doesn't support attributes.
 ### Implementation:
 > So custom card will have to make few callService to store the surveyjs intermittent states and in the end response data in a file 
-```
-    - to do this we can use the notify service for a file sensor entity. This will append a line at the end of the file. 
-    | Done implementation in the custom card by Mani
-
-    - callservice to run the python_scripts to read the last line of the .txt file and save it to the designated .json file.
-    | TODO write python_script, create a service call to run the python_script, call the service from the custom card. Pending implementation by Maharshi
-    - call homeassistant.update_entity service to update the RESTful sensor entity with the new state and attributes.
-
-```
-    
+- to do this we can use the notify service for a file sensor entity. This will append a line at the end of the file. 
+| Done implementation in the custom card by Mani
+- turn on automation that is triggered by the event of type [folder_watcher](https://www.home-assistant.io/integrations/folder_watcher/) and event_data of type modified. Add a condition to check if the file is the one we are looking for. Add an action to call the following services
+- callservice to run the python_scripts to read the last line of the .txt file and save it to the designated .json file.
+| TODO write python_script, create a service call to run the python_script, call the service from the custom card. Pending implementation by Maharshi
+- call homeassistant.update_entity service to update the RESTful sensor entity with the new state and attributes.

--- a/surveyjs_api_alt.md
+++ b/surveyjs_api_alt.md
@@ -29,3 +29,10 @@ Interesting Solutions/ideas on community:
 - callservice to run the python_scripts to read the last line of the .txt file and save it to the designated .json file.
 | TODO write python_script, create a service call to run the python_script, call the service from the custom card. Pending implementation by Maharshi
 - call homeassistant.update_entity service to update the RESTful sensor entity with the new state and attributes.
+
+
+Solution 2:
+- use HA input_text entity to store the JSON format surveyjs data in a HA file.
+- use HA service calls to post JSON response of less than 255 characters to HA input_text entity.
+- use HA service calls to maintain surveyjs lifecycle_state and associated time attr data in HA input_select(?) entity.
+- use HA service calls to start, check, finish surveyjs expiry timer in HA timer entity.

--- a/surveyjs_api_alt.md
+++ b/surveyjs_api_alt.md
@@ -1,0 +1,35 @@
+## Current constraints: 
+- HA doesn't support non-admin users to call apis 
+so traditional way of hass.callApi() is not possible. [code-source:](https://github.com/home-assistant/core/blob/f422dd418b95ce5ad1459d5296bf43b67d09dfa0/homeassistant/components/api/__init__.py#L292) 
+    - HA doesn't support non-admin users to make websocket connection either
+    - HA doesn't support non-admin users to make http request to HA server either
+## Possible solutions:
+- Only way forward is to use HA service calls to store the JSON format surveyjs data in a HA file. [code-source:](https://github.com/home-assistant/core/blob/f422dd418b95ce5ad1459d5296bf43b67d09dfa0/homeassistant/components/api/__init__.py#L323C1-L332C35 )
+
+    - Then use HA service calls to read the JSON format surveyjs lifecycle_state and attr data from this file and convert it to a sensor entity with lifecycle as state and response and metadata as attributes.
+    - the file sensor entity can be used to display the surveyjs data in HA frontend. the file sensor reads the last line of the file and converts it to a necessary format for HA frontend to display.
+
+
+Interesting Solutions/ideas on community:
+- [python_scripts](https://www.home-assistant.io/integrations/python_script/#calling-services)
+- [community ideas 1](https://community.home-assistant.io/t/reading-multiple-rows-from-csv/326335/12)
+- [community ideas 2](https://community.home-assistant.io/t/multiple-line-text-file-to-template-sensor-attributes/335904)
+- [community ideas 3](https://community.home-assistant.io/t/read-json-file-into-sensor/108104/6) [.sh file Github](https://github.com/DavidFW1960/ABB-Home-Assistant-Usage)
+
+## Proposed solution:
+### Explanation:
+- python script to read the text file and take last line which is a JSON string - store it in a .json file.  
+- use HA REST/command line sensor to read the .json file and convert it to a sensor entity with lifecycle as state and response and metadata as attributes.
+- reasons for not using file sensor - file sensor doesn't support attributes.
+### Implementation:
+> So custom card will have to make few callService to store the surveyjs intermittent states and in the end response data in a file 
+```
+    - to do this we can use the notify service for a file sensor entity. This will append a line at the end of the file. 
+    | Done implementation in the custom card by Mani
+
+    - callservice to run the python_scripts to read the last line of the .txt file and save it to the designated .json file.
+    | TODO write python_script, create a service call to run the python_script, call the service from the custom card. Pending implementation by Maharshi
+    - call homeassistant.update_entity service to update the RESTful sensor entity with the new state and attributes.
+
+```
+    

--- a/text2json.py
+++ b/text2json.py
@@ -1,0 +1,56 @@
+def read_last_line(filename):
+  """Reads the last line of a text file.
+
+  Args:
+    filename: The name of the text file.
+
+  Returns:
+    The last line of the text file, or an empty string if the file is empty.
+  """
+
+  with open(filename, "r") as f:
+    lines = f.readlines()
+  return lines[-1] if lines else ""
+
+def split_json_string(json_string):
+  """Splits a JSON string into a list of strings, one per line.
+
+  Args:
+    json_string: The JSON string.
+
+  Returns:
+    A list of strings, one per line of the JSON string.
+  """
+
+  lines = json_string.split("\n")
+  return [line.strip() for line in lines]
+
+def write_lines_to_file(lines, filename):
+  """Writes a list of strings to a file.
+
+  Args:
+    lines: The list of strings to write to the file.
+    filename: The name of the file to write to.
+  """
+
+  with open(filename, "w") as f:
+    for line in lines:
+      f.write(line + "\n")
+
+def main():
+  """The main function."""
+
+  text_filename = "data.txt"
+  json_filename = "data.json"
+
+  # Read the last line of the text file.
+  last_line = read_last_line(text_filename)
+
+  # Split the JSON string into a list of strings, one per line.
+  lines = split_json_string(last_line)
+
+  # Write the lines to the .JSON file.
+  write_lines_to_file(lines, json_filename)
+
+if __name__ == "__main__":
+  main()


### PR DESCRIPTION
Code changes for the changing the callApi to callService. 
Breaking changes: 
The survey configuration is governed by 3 main entities. All service calls are made to these entities depending on the state Action machine of the Survey Life cycle. Look for the image for more info on this. 
1. survey_response_entity is expected to be using "input_text" integration based entities.
2. state_life_cycle_entity is expected to be using "input_select" integration based entities.
3. for survey expiry; a timer integration based entity is being used by the custom card.

Below is a sample configuration. Rest of the configuration setting should continue as is. 

- survey_response_entity: input_text.surveyjsresponse
- state_life_cycle_entity: input_select.surveyjslc
- expiry_timer:
  - name: timer.surveyjsexpiry
    duration: '00:02:00'